### PR TITLE
Open editor in new tab

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,6 +20,7 @@ const appInfo = {
         {
           extension: "docx",
           routeName: "onlyoffice-editor",
+          newTab: true,
           newFileMenu: {
             menuTitle ($gettext) {
               return $gettext("Document")
@@ -37,6 +38,7 @@ const appInfo = {
         {
           extension: "xlsx",
           routeName: "onlyoffice-editor",
+          newTab: true,
           newFileMenu: {
             menuTitle ($gettext) {
               return $gettext("Spreadsheet")
@@ -54,6 +56,7 @@ const appInfo = {
         {
           extension: "pptx",
           routeName: "onlyoffice-editor",
+          newTab: true,
           newFileMenu: {
             menuTitle ($gettext) {
               return $gettext("Presentation")


### PR DESCRIPTION
IMO the user experience is a little bit better when ONLYOFFICE opens in a new tab, since the ownCloud Web layout (left and top bar) is not available in the editor window.

This proposal is aligned with our product management. Happy to discuss it further if you don't like it. ;-)
cc @tbsbdr